### PR TITLE
Main

### DIFF
--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -34,7 +34,8 @@
             #binding-cells = <0>;
             // Alternative: K_VOLUME_UP
             bindings = <&macro_release &kp LSHFT &kp RSHFT>, 
-                       <&macro_tap &kp C_VOLUME_UP>;
+                       <&macro_tap &kp C_VOLUME_UP>,
+                       <&macro_press &kp LSHFT &kp RSHFT>;
         };
         
         // Macro that releases modifiers before sending volume down  
@@ -43,7 +44,8 @@
             #binding-cells = <0>;
             // Alternative: K_VOLUME_DOWN
             bindings = <&macro_release &kp LSHFT &kp RSHFT>,
-                       <&macro_tap &kp C_VOLUME_DOWN>;
+                       <&macro_tap &kp C_VOLUME_DOWN>,
+                       <&macro_press &kp LSHFT &kp RSHFT>;
         };
     };
     

--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -43,15 +43,15 @@
       up_volume: up_volume {
           compatible = "zmk,behavior-mod-morph";
           #binding-cells = <0>;
-          // Alternative: K_VOL_UP
-          bindings = <&kp UP>, <&kp C_VOL_UP>;
+          // Alternative: K_VOLUME_UP
+          bindings = <&kp UP>, <&kp C_VOLUME_UP>;
           mods = <(MOD_LSFT|MOD_RSFT)>;
       };
       down_volume: down_volume {
           compatible = "zmk,behavior-mod-morph";
           #binding-cells = <0>;
-          // Alternative: K_VOL_DOWN
-          bindings = <&kp DOWN>, <&kp C_VOL_DOWN>;
+          // Alternative: K_VOLUME_DOWN
+          bindings = <&kp DOWN>, <&kp C_VOLUME_DOWN>;
           mods = <(MOD_LSFT|MOD_RSFT)>;
       };
     };

--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -86,7 +86,7 @@
       combo_RHS_shift_carat_disable {
         timeout-ms = <2000>;
         key-positions = <8 59>;
-        bindings = <&kp 6>;
+        bindings = <&kp N6>;
       };
       combo_media_next {
         timeout-ms = <2000>;
@@ -120,11 +120,11 @@
     default_layer {
       display-name = "Base";
       bindings = <
-        &kp EQUAL &kp N1    &kp N2   &kp N3   &kp N4     &kp N5 &tog 1                                                               &mo 3     &kp N6 &kp N7        &kp N8           &kp N9   &kp N0   &kp MINUS
-        &kp TAB   &kp Q     &kp W    &kp E    &kp R      &kp T  &none                                                                &none     &kp Y  &kp U         &kp I            &kp O    &kp P    &kp BSLH
-        &kp ESC   &kp A     &kp S    &kp D    &kp F      &kp G  &kp LC(B)           &kp LCTRL &kp LALT &kp LGUI  &kp RCTRL           &kp LC(B) &kp H  &kp J         &kp K            &kp L    &kp SEMI &kp SQT
-        &kp LSHFT &kp Z     &kp X    &kp C    &kp V      &kp B                                &kp HOME &kp PG_UP                               &kp N  &kp M         &kp COMMA        &kp DOT  &kp FSLH &kp RSHFT
-        &mo 2     &kp GRAVE &kp CAPS &kp LEFT &kp RIGHT                    &kp BSPC &kp DEL   &kp END  &kp PG_DN &kp ENTER &kp SPACE                  &kp up_volume &kp down_volume  &kp LBKT &kp RBKT &mo 2
+        &kp EQUAL &kp N1    &kp N2   &kp N3   &kp N4     &kp N5 &tog 1                                                               &mo 3     &kp N6 &kp N7     &kp N8       &kp N9   &kp N0   &kp MINUS
+        &kp TAB   &kp Q     &kp W    &kp E    &kp R      &kp T  &none                                                                &none     &kp Y  &kp U      &kp I        &kp O    &kp P    &kp BSLH
+        &kp ESC   &kp A     &kp S    &kp D    &kp F      &kp G  &kp LC(B)           &kp LCTRL &kp LALT &kp LGUI  &kp RCTRL           &kp LC(B) &kp H  &kp J      &kp K        &kp L    &kp SEMI &kp SQT
+        &kp LSHFT &kp Z     &kp X    &kp C    &kp V      &kp B                                &kp HOME &kp PG_UP                               &kp N  &kp M      &kp COMMA    &kp DOT  &kp FSLH &kp RSHFT
+        &mo 2     &kp GRAVE &kp CAPS &kp LEFT &kp RIGHT                    &kp BSPC &kp DEL   &kp END  &kp PG_DN &kp ENTER &kp SPACE                  &up_volume &down_volume &kp LBKT &kp RBKT &mo 2
       >;
     };
     keypad {

--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -28,11 +28,11 @@
     default_layer {
       display-name = "Base";
       bindings = <
-        &kp EQUAL &kp N1    &kp N2   &kp N3   &kp N4     &kp N5 &tog 1                                                           &mo 3 &kp N6 &kp N7 &kp N8    &kp N9   &kp N0   &kp MINUS
-        &kp TAB   &kp Q     &kp W    &kp E    &kp R      &kp T  &none                                                            &none &kp Y  &kp U  &kp I     &kp O    &kp P    &kp BSLH
-        &kp ESC   &kp A     &kp S    &kp D    &kp F      &kp G  &none           &kp LCTRL &kp LALT &kp LGUI  &kp RCTRL           &none &kp H  &kp J  &kp K     &kp L    &kp SEMI &kp SQT
-        &kp LSHFT &kp Z     &kp X    &kp C    &kp V      &kp B                            &kp HOME &kp PG_UP                           &kp N  &kp M  &kp COMMA &kp DOT  &kp FSLH &kp RSHFT
-        &mo 2     &kp GRAVE &kp CAPS &kp LEFT &kp RIGHT                &kp BSPC &kp DEL   &kp END  &kp PG_DN &kp ENTER &kp SPACE              &kp UP &kp DOWN  &kp LBKT &kp RBKT &mo 2
+        &kp EQUAL &kp N1    &kp N2   &kp N3   &kp N4     &kp N5 &tog 1                                                               &mo 3     &kp N6 &kp N7 &kp N8    &kp N9   &kp N0   &kp MINUS
+        &kp TAB   &kp Q     &kp W    &kp E    &kp R      &kp T  &none                                                                &none     &kp Y  &kp U  &kp I     &kp O    &kp P    &kp BSLH
+        &kp ESC   &kp A     &kp S    &kp D    &kp F      &kp G  &kp LC(B)           &kp LCTRL &kp LALT &kp LGUI  &kp RCTRL           &kp LC(B) &kp H  &kp J  &kp K     &kp L    &kp SEMI &kp SQT
+        &kp LSHFT &kp Z     &kp X    &kp C    &kp V      &kp B                                &kp HOME &kp PG_UP                               &kp N  &kp M  &kp COMMA &kp DOT  &kp FSLH &kp RSHFT
+        &mo 2     &kp GRAVE &kp CAPS &kp LEFT &kp RIGHT                    &kp BSPC &kp DEL   &kp END  &kp PG_DN &kp ENTER &kp SPACE                  &kp UP &kp DOWN  &kp LBKT &kp RBKT &mo 2
       >;
     };
     keypad {

--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -6,38 +6,23 @@
 #include <dt-bindings/zmk/backlight.h>
 #include <dt-bindings/zmk/pointing.h>
 
-#define KEYS_LEFT 0 1 2 3 4 5 6 \
-                  14 15 16 17 18 19 20 \
-                  28 29 30 31 32 33 34 \
-                  46 47 48 49 50 51 \
-                  60 61 62 63 64
+// #define KEYS_LEFT 0 1 2 3 4 5 6 \
+//                   14 15 16 17 18 19 20 \
+//                   28 29 30 31 32 33 34 \
+//                   46 47 48 49 50 51 \
+//                   60 61 62 63 64
 
-#define KEYS_RIGHT 7 8 9 10 11 12 13 \
-                   21 22 23 24 25 26 27 \
-                   39 40 41 42 43 44 45 \
-                   54 55 56 57 58 59 \
-                   71 72 73 74 75
+// #define KEYS_RIGHT 7 8 9 10 11 12 13 \
+//                    21 22 23 24 25 26 27 \
+//                    39 40 41 42 43 44 45 \
+//                    54 55 56 57 58 59 \
+//                    71 72 73 74 75
 
-#define THUMBS_LEFT 35 36 52 65 66 67
+// #define THUMBS_LEFT 35 36 52 65 66 67
 
-#define THUMBS_RIGHT 37 38 53 68 69 70
+// #define THUMBS_RIGHT 37 38 53 68 69 70
 
 / {
-    behaviors {
-      #include "macros.dtsi"
-      #include "version.dtsi"
-
-      hm: homerow_mods {
-          compatible = "zmk,behavior-hold-tap";
-          label = "HOMEROW_MODS";
-          #binding-cells = <2>;
-          tapping-term-ms = <200>;
-          quick_tap_ms = <175>;
-          flavor = "tap-preferred";
-          bindings = <&kp>, <&kp>;
-      };
-    };
-    
     combos {
       compatible = "zmk,combos";
       combo_volume_up {
@@ -75,6 +60,23 @@
         key-positions = <34 59>;
         // Alternative: C_PLAY_PAUSE
         binding = <&kp K_PLAY_PAUSE>;
+      };
+    };
+};
+
+/ {
+    behaviors {
+      #include "macros.dtsi"
+      #include "version.dtsi"
+
+      hm: homerow_mods {
+          compatible = "zmk,behavior-hold-tap";
+          label = "HOMEROW_MODS";
+          #binding-cells = <2>;
+          tapping-term-ms = <200>;
+          quick_tap_ms = <175>;
+          flavor = "tap-preferred";
+          bindings = <&kp>, <&kp>;
       };
     };
 

--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -102,11 +102,11 @@
     fn {
       display-name = "Fn";
       bindings = <
-        &kp F1 &kp F2 &kp F3 &kp F4         &kp F5     &kp F6  &tog 1                                                     &mo 3            &kp F7 &kp F8 &kp F9 &kp F10 &kp F11 &kp F12
-        &trans &trans &trans &trans         &trans     &trans  &none                                                      &none            &trans &trans &trans &trans  &trans  &trans
-        &trans &trans &trans &trans         &trans     &trans  &kp C_PLAY_PAUSE        &trans &trans &trans &trans        &kp C_PLAY_PAUSE &trans &trans &trans &trans  &trans  &trans
-        &trans &trans &trans &trans         &trans     &trans                                 &trans &trans                                &trans &trans &trans &trans  &trans  &trans
-        &trans &trans &trans &kp C_PREVIOUS &kp C_NEXT                          &trans &trans &trans &trans &trans &trans                          &trans &trans &trans  &trans  &trans
+        &kp F1 &kp F2 &kp F3 &kp F4         &kp F5     &kp F6  &tog 1                                                     &mo 3            &kp F7 &kp F8          &kp F9            &kp F10 &kp F11 &kp F12
+        &trans &trans &trans &trans         &trans     &trans  &none                                                      &none            &trans &trans          &trans            &trans  &trans  &trans
+        &trans &trans &trans &trans         &trans     &trans  &kp C_PLAY_PAUSE        &trans &trans &trans &trans        &kp C_PLAY_PAUSE &trans &trans          &trans            &trans  &trans  &trans
+        &trans &trans &trans &trans         &trans     &trans                                 &trans &trans                                &trans &trans          &trans            &trans  &trans  &trans
+        &trans &trans &trans &kp C_PREVIOUS &kp C_NEXT                          &trans &trans &trans &trans &trans &trans                         &kp C_VOLUME_UP &kp C_VOLUME_DOWN &trans  &trans  &trans
       >;
     };
     mod {

--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -44,6 +44,11 @@
     
     combos {
       compatible = "zmk,combos";
+      combo_test {
+        timeout-ms = <100>;
+        key-positions = <0 1>;
+        bindings = <&kp ESC>;
+      };
       combo_volume_up {
         timeout-ms = <100>;
         key-positions = <46 71>;

--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -6,6 +6,64 @@
 #include <dt-bindings/zmk/backlight.h>
 #include <dt-bindings/zmk/pointing.h>
 
+// #define KEYS_LEFT 0 1 2 3 4 5 6 \
+//                   14 15 16 17 18 19 20 \
+//                   28 29 30 31 32 33 34 \
+//                   46 47 48 49 50 51 \
+//                   60 61 62 63 64
+
+// #define KEYS_RIGHT 7 8 9 10 11 12 13 \
+//                    21 22 23 24 25 26 27 \
+//                    39 40 41 42 43 44 45 \
+//                    54 55 56 57 58 59 \
+//                    71 72 73 74 75
+
+// #define THUMBS_LEFT 35 36 52 65 66 67
+
+// #define THUMBS_RIGHT 37 38 53 68 69 70
+
+/ {
+    combos {
+      compatible = "zmk,combos";
+      combo_volume_up {
+        timeout-ms = <50>;
+        key-positions = <46 71>;
+        // Alternative: C_VOLUME_UP
+        bindings = <&kp K_VOLUME_UP>;
+      };
+      combo_volume_down {
+        timeout-ms = <50>;
+        key-positions = <46 72>;
+        // Alternative: C_VOLUME_DOWN
+        bindings = <&kp K_VOLUME_DOWN>;
+      };
+      combo_media_next {
+        timeout-ms = <50>;
+        key-positions = <59 64>;
+        // Alternative: C_NEXT
+        bindings = <&kp K_NEXT>;
+      };
+      combo_media_prev {
+        timeout-ms = <50>;
+        key-positions = <59 63>;
+        // Alternative: C_PREVIOUS
+        bindings = <&kp K_PREVIOUS>;
+      };
+      combo_media_play_pause_1 {
+        timeout-ms = <50>;
+        key-positions = <39 46>;
+        // Alternative: C_PLAY_PAUSE
+        bindings = <&kp K_PLAY_PAUSE>;
+      };
+      combo_media_play_pause_2 {
+        timeout-ms = <50>;
+        key-positions = <34 59>;
+        // Alternative: C_PLAY_PAUSE
+        bindings = <&kp K_PLAY_PAUSE>;
+      };
+    };
+};
+
 / {
     behaviors {
       #include "macros.dtsi"

--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -6,6 +6,22 @@
 #include <dt-bindings/zmk/backlight.h>
 #include <dt-bindings/zmk/pointing.h>
 
+#define KEYS_LEFT 0 1 2 3 4 5 6 \
+                  14 15 16 17 18 19 20 \
+                  28 29 30 31 32 33 34 \
+                  46 47 48 49 50 51 \
+                  60 61 62 63 64
+
+#define KEYS_RIGHT 7 8 9 10 11 12 13 \
+                   21 22 23 24 25 26 27 \
+                   39 40 41 42 43 44 45 \
+                   54 55 56 57 58 59 \
+                   71 72 73 74 75
+
+#define THUMBS_LEFT 35 36 52 65 66 67
+
+#define THUMBS_RIGHT 37 38 53 68 69 70
+
 / {
     behaviors {
       #include "macros.dtsi"
@@ -21,6 +37,46 @@
           bindings = <&kp>, <&kp>;
       };
     };
+    
+    combos {
+      compatible = "zmk,combos";
+      combo_volume_up {
+        timeout-ms = <50>;
+        key-positions = <46 71>;
+        // Alternative: C_VOLUME_UP
+        binding = <&kp K_VOLUME_UP>;
+      };
+      combo_volume_down {
+        timeout-ms = <50>;
+        key-positions = <46 72>;
+        // Alternative: C_VOLUME_DOWN
+        binding = <&kp K_VOLUME_DOWN>;
+      };
+      combo_media_next {
+        timeout-ms = <50>;
+        key-positions = <59 64>;
+        // Alternative: C_NEXT
+        binding = <&kp K_NEXT>;
+      };
+      combo_media_prev {
+        timeout-ms = <50>;
+        key-positions = <59 63>;
+        // Alternative: C_PREVIOUS
+        binding = <&kp K_PREVIOUS>;
+      };
+      combo_media_play_pause_1 {
+        timeout-ms = <50>;
+        key-positions = <39 46>;
+        // Alternative: C_PLAY_PAUSE
+        binding = <&kp K_PLAY_PAUSE>;
+      };
+      combo_media_play_pause_2 {
+        timeout-ms = <50>;
+        key-positions = <34 59>;
+        // Alternative: C_PLAY_PAUSE
+        binding = <&kp K_PLAY_PAUSE>;
+      };
+    };
 
   keymap {
     compatible = "zmk,keymap";
@@ -28,11 +84,11 @@
     default_layer {
       display-name = "Base";
       bindings = <
-        &kp EQUAL &kp N1    &kp N2   &kp N3   &kp N4     &kp N5 &tog 1                                                           &mo 3 &kp N6 &kp N7 &kp N8    &kp N9   &kp N0   &kp MINUS
-        &kp TAB   &kp Q     &kp W    &kp E    &kp R      &kp T  &none                                                            &none &kp Y  &kp U  &kp I     &kp O    &kp P    &kp BSLH
-        &kp ESC   &kp A     &kp S    &kp D    &kp F      &kp G  &none           &kp LCTRL &kp LALT &kp LGUI  &kp RCTRL           &none &kp H  &kp J  &kp K     &kp L    &kp SEMI &kp SQT
-        &kp LSHFT &kp Z     &kp X    &kp C    &kp V      &kp B                            &kp HOME &kp PG_UP                           &kp N  &kp M  &kp COMMA &kp DOT  &kp FSLH &kp RSHFT
-        &mo 2     &kp GRAVE &kp CAPS &kp LEFT &kp RIGHT                &kp BSPC &kp DEL   &kp END  &kp PG_DN &kp ENTER &kp SPACE              &kp UP &kp DOWN  &kp LBKT &kp RBKT &mo 2
+        &kp EQUAL &kp N1    &kp N2   &kp N3   &kp N4     &kp N5 &tog 1                                                               &mo 3     &kp N6 &kp N7 &kp N8    &kp N9   &kp N0   &kp MINUS
+        &kp TAB   &kp Q     &kp W    &kp E    &kp R      &kp T  &none                                                                &none     &kp Y  &kp U  &kp I     &kp O    &kp P    &kp BSLH
+        &kp ESC   &kp A     &kp S    &kp D    &kp F      &kp G  &kp LC(B)           &kp LCTRL &kp LALT &kp LGUI  &kp RCTRL           &kp LC(B) &kp H  &kp J  &kp K     &kp L    &kp SEMI &kp SQT
+        &kp LSHFT &kp Z     &kp X    &kp C    &kp V      &kp B                                &kp HOME &kp PG_UP                               &kp N  &kp M  &kp COMMA &kp DOT  &kp FSLH &kp RSHFT
+        &mo 2     &kp GRAVE &kp CAPS &kp LEFT &kp RIGHT                    &kp BSPC &kp DEL   &kp END  &kp PG_DN &kp ENTER &kp SPACE                  &kp UP &kp DOWN  &kp LBKT &kp RBKT &mo 2
       >;
     };
     keypad {

--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -45,42 +45,42 @@
     combos {
       compatible = "zmk,combos";
       combo_test {
-        timeout-ms = <100>;
+        timeout-ms = <1000>;
         key-positions = <0 1>;
         bindings = <&kp ESC>;
       };
       combo_volume_up {
-        timeout-ms = <100>;
+        timeout-ms = <1000>;
         key-positions = <46 71>;
         // Alternative: K_VOLUME_UP
         bindings = <&kp C_VOLUME_UP>;
       };
       combo_volume_down {
-        timeout-ms = <100>;
+        timeout-ms = <1000>;
         key-positions = <46 72>;
         // Alternative: K_VOLUME_DOWN
         bindings = <&kp C_VOLUME_DOWN>;
       };
       combo_media_next {
-        timeout-ms = <100>;
+        timeout-ms = <1000>;
         key-positions = <59 64>;
         // Alternative: K_NEXT
         bindings = <&kp C_NEXT>;
       };
       combo_media_prev {
-        timeout-ms = <100>;
+        timeout-ms = <1000>;
         key-positions = <59 63>;
         // Alternative: K_PREVIOUS
         bindings = <&kp C_PREVIOUS>;
       };
       combo_media_play_pause_1 {
-        timeout-ms = <100>;
+        timeout-ms = <1000>;
         key-positions = <39 46>;
         // Alternative: K_PLAY_PAUSE
         bindings = <&kp C_PLAY_PAUSE>;
       };
       combo_media_play_pause_2 {
-        timeout-ms = <100>;
+        timeout-ms = <1000>;
         key-positions = <34 59>;
         // Alternative: K_PLAY_PAUSE
         bindings = <&kp C_PLAY_PAUSE>;

--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -27,6 +27,26 @@
 //                      68 69 70 \
 
 / {
+    macros {
+        // Macro that releases modifiers before sending volume up
+        vol_up_macro: vol_up_macro {
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            // Alternative: K_VOLUME_UP
+            bindings = <&macro_release &kp LSHFT &kp RSHFT>, 
+                       <&macro_tap &kp C_VOLUME_UP>;
+        };
+        
+        // Macro that releases modifiers before sending volume down  
+        vol_down_macro: vol_down_macro {
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            // Alternative: K_VOLUME_DOWN
+            bindings = <&macro_release &kp LSHFT &kp RSHFT>,
+                       <&macro_tap &kp C_VOLUME_DOWN>;
+        };
+    };
+    
     behaviors {
       #include "macros.dtsi"
       #include "version.dtsi"
@@ -43,15 +63,13 @@
       up_volume: up_volume {
           compatible = "zmk,behavior-mod-morph";
           #binding-cells = <0>;
-          // Alternative: K_VOLUME_UP
-          bindings = <&kp UP>, <&kp C_VOLUME_UP>;
+          bindings = <&kp UP>, <&vol_up_macro>;
           mods = <(MOD_LSFT|MOD_RSFT)>;
       };
       down_volume: down_volume {
           compatible = "zmk,behavior-mod-morph";
           #binding-cells = <0>;
-          // Alternative: K_VOLUME_DOWN
-          bindings = <&kp DOWN>, <&kp C_VOLUME_DOWN>;
+          bindings = <&kp DOWN>, <&vol_down_macro>;
           mods = <(MOD_LSFT|MOD_RSFT)>;
       };
     };

--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -56,6 +56,24 @@
         key-positions = <0 46>;
         bindings = <&kp RS(EQUAL)>;
       };
+      // To allow "opposite shift mode" in MonkeyType to work.
+      combo_LHS_shift_b_disable {
+        timeout-ms = <2000>;
+        key-positions = <46 51>;
+        bindings = <&kp B>;
+      };
+      // To allow "opposite shift mode" in MonkeyType to work.
+      combo_RHS_shift_y_disable {
+        timeout-ms = <2000>;
+        key-positions = <22 59>;
+        bindings = <&kp Y>;
+      };
+      // To allow "opposite shift mode" in MonkeyType to work.
+      combo_RHS_shift_carat_disable {
+        timeout-ms = <2000>;
+        key-positions = <8 59>;
+        bindings = <&kp 6>;
+      };
       combo_volume_up {
         timeout-ms = <2000>;
         key-positions = <46 71>;

--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -6,21 +6,25 @@
 #include <dt-bindings/zmk/backlight.h>
 #include <dt-bindings/zmk/pointing.h>
 
-// #define KEYS_LEFT 0 1 2 3 4 5 6 \
-//                   14 15 16 17 18 19 20 \
-//                   28 29 30 31 32 33 34 \
-//                   46 47 48 49 50 51 \
-//                   60 61 62 63 64
+// #define KEYS_L   0  1  2  3  4  5  6 \
+//                 14 15 16 17 18 19 20 \
+//                 28 29 30 31 32 33 34 \
+//                 46 47 48 49 50 51    \
+//                 60 61 62 63 64
 
-// #define KEYS_RIGHT 7 8 9 10 11 12 13 \
-//                    21 22 23 24 25 26 27 \
-//                    39 40 41 42 43 44 45 \
+// #define THUMBS_LEFT     35 36 \
+//                            52 \
+//                      65 66 67 \
+
+// #define KEYS_R   7  8  9 10 11 12 13 \
+//                 21 22 23 24 25 26 27 \
+//                 39 40 41 42 43 44 45 \
 //                    54 55 56 57 58 59 \
-//                    71 72 73 74 75
+//                       71 72 73 74 75
 
-// #define THUMBS_LEFT 35 36 52 65 66 67
-
-// #define THUMBS_RIGHT 37 38 53 68 69 70
+// #define THUMBS_RIGHT 37 38    \
+//                      53       \
+//                      68 69 70 \
 
 / {
     behaviors {
@@ -41,40 +45,40 @@
     combos {
       compatible = "zmk,combos";
       combo_volume_up {
-        timeout-ms = <50>;
+        timeout-ms = <100>;
         key-positions = <46 71>;
-        // Alternative: C_VOLUME_UP
-        bindings = <&kp K_VOLUME_UP>;
+        // Alternative: K_VOLUME_UP
+        bindings = <&kp C_VOLUME_UP>;
       };
       combo_volume_down {
-        timeout-ms = <50>;
+        timeout-ms = <100>;
         key-positions = <46 72>;
-        // Alternative: C_VOLUME_DOWN
-        bindings = <&kp K_VOLUME_DOWN>;
+        // Alternative: K_VOLUME_DOWN
+        bindings = <&kp C_VOLUME_DOWN>;
       };
       combo_media_next {
-        timeout-ms = <50>;
+        timeout-ms = <100>;
         key-positions = <59 64>;
-        // Alternative: C_NEXT
-        bindings = <&kp K_NEXT>;
+        // Alternative: K_NEXT
+        bindings = <&kp C_NEXT>;
       };
       combo_media_prev {
-        timeout-ms = <50>;
+        timeout-ms = <100>;
         key-positions = <59 63>;
-        // Alternative: C_PREVIOUS
-        bindings = <&kp K_PREVIOUS>;
+        // Alternative: K_PREVIOUS
+        bindings = <&kp C_PREVIOUS>;
       };
       combo_media_play_pause_1 {
-        timeout-ms = <50>;
+        timeout-ms = <100>;
         key-positions = <39 46>;
-        // Alternative: C_PLAY_PAUSE
-        bindings = <&kp K_PLAY_PAUSE>;
+        // Alternative: K_PLAY_PAUSE
+        bindings = <&kp C_PLAY_PAUSE>;
       };
       combo_media_play_pause_2 {
-        timeout-ms = <50>;
+        timeout-ms = <100>;
         key-positions = <34 59>;
-        // Alternative: C_PLAY_PAUSE
-        bindings = <&kp K_PLAY_PAUSE>;
+        // Alternative: K_PLAY_PAUSE
+        bindings = <&kp C_PLAY_PAUSE>;
       };
     };
 

--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -44,43 +44,50 @@
     
     combos {
       compatible = "zmk,combos";
-      combo_test {
-        timeout-ms = <1000>;
-        key-positions = <0 1>;
-        bindings = <&kp ESC>;
+      // To allow "opposite shift mode" in MonkeyType to work.
+      combo_LHS_shift_swap {
+        timeout-ms = <2000>;
+        key-positions = <0 59>;
+        bindings = <&kp LS(EQUAL)>;
+      };
+      // To allow "opposite shift mode" in MonkeyType to work.
+      combo_RHS_shift_swap {
+        timeout-ms = <2000>;
+        key-positions = <0 46>;
+        bindings = <&kp RS(EQUAL)>;
       };
       combo_volume_up {
-        timeout-ms = <1000>;
+        timeout-ms = <2000>;
         key-positions = <46 71>;
         // Alternative: K_VOLUME_UP
         bindings = <&kp C_VOLUME_UP>;
       };
       combo_volume_down {
-        timeout-ms = <1000>;
+        timeout-ms = <2000>;
         key-positions = <46 72>;
         // Alternative: K_VOLUME_DOWN
         bindings = <&kp C_VOLUME_DOWN>;
       };
       combo_media_next {
-        timeout-ms = <1000>;
+        timeout-ms = <2000>;
         key-positions = <59 64>;
         // Alternative: K_NEXT
         bindings = <&kp C_NEXT>;
       };
       combo_media_prev {
-        timeout-ms = <1000>;
+        timeout-ms = <2000>;
         key-positions = <59 63>;
         // Alternative: K_PREVIOUS
         bindings = <&kp C_PREVIOUS>;
       };
       combo_media_play_pause_1 {
-        timeout-ms = <1000>;
+        timeout-ms = <2000>;
         key-positions = <39 46>;
         // Alternative: K_PLAY_PAUSE
         bindings = <&kp C_PLAY_PAUSE>;
       };
       combo_media_play_pause_2 {
-        timeout-ms = <1000>;
+        timeout-ms = <2000>;
         key-positions = <34 59>;
         // Alternative: K_PLAY_PAUSE
         bindings = <&kp C_PLAY_PAUSE>;

--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -23,6 +23,21 @@
 // #define THUMBS_RIGHT 37 38 53 68 69 70
 
 / {
+    behaviors {
+      #include "macros.dtsi"
+      #include "version.dtsi"
+
+      hm: homerow_mods {
+          compatible = "zmk,behavior-hold-tap";
+          label = "HOMEROW_MODS";
+          #binding-cells = <2>;
+          tapping-term-ms = <200>;
+          quick_tap_ms = <175>;
+          flavor = "tap-preferred";
+          bindings = <&kp>, <&kp>;
+      };
+    };
+    
     combos {
       compatible = "zmk,combos";
       combo_volume_up {
@@ -60,23 +75,6 @@
         key-positions = <34 59>;
         // Alternative: C_PLAY_PAUSE
         bindings = <&kp K_PLAY_PAUSE>;
-      };
-    };
-};
-
-/ {
-    behaviors {
-      #include "macros.dtsi"
-      #include "version.dtsi"
-
-      hm: homerow_mods {
-          compatible = "zmk,behavior-hold-tap";
-          label = "HOMEROW_MODS";
-          #binding-cells = <2>;
-          tapping-term-ms = <200>;
-          quick_tap_ms = <175>;
-          flavor = "tap-preferred";
-          bindings = <&kp>, <&kp>;
       };
     };
 

--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -40,6 +40,20 @@
           flavor = "tap-preferred";
           bindings = <&kp>, <&kp>;
       };
+      up_volume: up_volume {
+          compatible = "zmk,behavior-mod-morph";
+          #binding-cells = <0>;
+          // Alternative: K_VOL_UP
+          bindings = <&kp UP>, <&kp C_VOL_UP>;
+          mods = <(MOD_LSFT|MOD_RSFT)>;
+      };
+      down_volume: down_volume {
+          compatible = "zmk,behavior-mod-morph";
+          #binding-cells = <0>;
+          // Alternative: K_VOL_DOWN
+          bindings = <&kp DOWN>, <&kp C_VOL_DOWN>;
+          mods = <(MOD_LSFT|MOD_RSFT)>;
+      };
     };
     
     combos {
@@ -74,18 +88,6 @@
         key-positions = <8 59>;
         bindings = <&kp 6>;
       };
-      combo_volume_up {
-        timeout-ms = <2000>;
-        key-positions = <46 71>;
-        // Alternative: K_VOLUME_UP
-        bindings = <&kp C_VOLUME_UP>;
-      };
-      combo_volume_down {
-        timeout-ms = <2000>;
-        key-positions = <46 72>;
-        // Alternative: K_VOLUME_DOWN
-        bindings = <&kp C_VOLUME_DOWN>;
-      };
       combo_media_next {
         timeout-ms = <2000>;
         key-positions = <59 64>;
@@ -118,11 +120,11 @@
     default_layer {
       display-name = "Base";
       bindings = <
-        &kp EQUAL &kp N1    &kp N2   &kp N3   &kp N4     &kp N5 &tog 1                                                               &mo 3     &kp N6 &kp N7 &kp N8    &kp N9   &kp N0   &kp MINUS
-        &kp TAB   &kp Q     &kp W    &kp E    &kp R      &kp T  &none                                                                &none     &kp Y  &kp U  &kp I     &kp O    &kp P    &kp BSLH
-        &kp ESC   &kp A     &kp S    &kp D    &kp F      &kp G  &kp LC(B)           &kp LCTRL &kp LALT &kp LGUI  &kp RCTRL           &kp LC(B) &kp H  &kp J  &kp K     &kp L    &kp SEMI &kp SQT
-        &kp LSHFT &kp Z     &kp X    &kp C    &kp V      &kp B                                &kp HOME &kp PG_UP                               &kp N  &kp M  &kp COMMA &kp DOT  &kp FSLH &kp RSHFT
-        &mo 2     &kp GRAVE &kp CAPS &kp LEFT &kp RIGHT                    &kp BSPC &kp DEL   &kp END  &kp PG_DN &kp ENTER &kp SPACE                  &kp UP &kp DOWN  &kp LBKT &kp RBKT &mo 2
+        &kp EQUAL &kp N1    &kp N2   &kp N3   &kp N4     &kp N5 &tog 1                                                               &mo 3     &kp N6 &kp N7        &kp N8           &kp N9   &kp N0   &kp MINUS
+        &kp TAB   &kp Q     &kp W    &kp E    &kp R      &kp T  &none                                                                &none     &kp Y  &kp U         &kp I            &kp O    &kp P    &kp BSLH
+        &kp ESC   &kp A     &kp S    &kp D    &kp F      &kp G  &kp LC(B)           &kp LCTRL &kp LALT &kp LGUI  &kp RCTRL           &kp LC(B) &kp H  &kp J         &kp K            &kp L    &kp SEMI &kp SQT
+        &kp LSHFT &kp Z     &kp X    &kp C    &kp V      &kp B                                &kp HOME &kp PG_UP                               &kp N  &kp M         &kp COMMA        &kp DOT  &kp FSLH &kp RSHFT
+        &mo 2     &kp GRAVE &kp CAPS &kp LEFT &kp RIGHT                    &kp BSPC &kp DEL   &kp END  &kp PG_DN &kp ENTER &kp SPACE                  &kp up_volume &kp down_volume  &kp LBKT &kp RBKT &mo 2
       >;
     };
     keypad {

--- a/config/adv360.keymap
+++ b/config/adv360.keymap
@@ -27,28 +27,6 @@
 //                      68 69 70 \
 
 / {
-    macros {
-        // Macro that releases modifiers before sending volume up
-        vol_up_macro: vol_up_macro {
-            compatible = "zmk,behavior-macro";
-            #binding-cells = <0>;
-            // Alternative: K_VOLUME_UP
-            bindings = <&macro_release &kp LSHFT &kp RSHFT>, 
-                       <&macro_tap &kp C_VOLUME_UP>,
-                       <&macro_press &kp LSHFT &kp RSHFT>;
-        };
-        
-        // Macro that releases modifiers before sending volume down  
-        vol_down_macro: vol_down_macro {
-            compatible = "zmk,behavior-macro";
-            #binding-cells = <0>;
-            // Alternative: K_VOLUME_DOWN
-            bindings = <&macro_release &kp LSHFT &kp RSHFT>,
-                       <&macro_tap &kp C_VOLUME_DOWN>,
-                       <&macro_press &kp LSHFT &kp RSHFT>;
-        };
-    };
-    
     behaviors {
       #include "macros.dtsi"
       #include "version.dtsi"
@@ -61,18 +39,6 @@
           quick_tap_ms = <175>;
           flavor = "tap-preferred";
           bindings = <&kp>, <&kp>;
-      };
-      up_volume: up_volume {
-          compatible = "zmk,behavior-mod-morph";
-          #binding-cells = <0>;
-          bindings = <&kp UP>, <&vol_up_macro>;
-          mods = <(MOD_LSFT|MOD_RSFT)>;
-      };
-      down_volume: down_volume {
-          compatible = "zmk,behavior-mod-morph";
-          #binding-cells = <0>;
-          bindings = <&kp DOWN>, <&vol_down_macro>;
-          mods = <(MOD_LSFT|MOD_RSFT)>;
       };
     };
     
@@ -108,30 +74,6 @@
         key-positions = <8 59>;
         bindings = <&kp N6>;
       };
-      combo_media_next {
-        timeout-ms = <2000>;
-        key-positions = <59 64>;
-        // Alternative: K_NEXT
-        bindings = <&kp C_NEXT>;
-      };
-      combo_media_prev {
-        timeout-ms = <2000>;
-        key-positions = <59 63>;
-        // Alternative: K_PREVIOUS
-        bindings = <&kp C_PREVIOUS>;
-      };
-      combo_media_play_pause_1 {
-        timeout-ms = <2000>;
-        key-positions = <39 46>;
-        // Alternative: K_PLAY_PAUSE
-        bindings = <&kp C_PLAY_PAUSE>;
-      };
-      combo_media_play_pause_2 {
-        timeout-ms = <2000>;
-        key-positions = <34 59>;
-        // Alternative: K_PLAY_PAUSE
-        bindings = <&kp C_PLAY_PAUSE>;
-      };
     };
 
   keymap {
@@ -140,11 +82,11 @@
     default_layer {
       display-name = "Base";
       bindings = <
-        &kp EQUAL &kp N1    &kp N2   &kp N3   &kp N4     &kp N5 &tog 1                                                               &mo 3     &kp N6 &kp N7     &kp N8       &kp N9   &kp N0   &kp MINUS
-        &kp TAB   &kp Q     &kp W    &kp E    &kp R      &kp T  &none                                                                &none     &kp Y  &kp U      &kp I        &kp O    &kp P    &kp BSLH
-        &kp ESC   &kp A     &kp S    &kp D    &kp F      &kp G  &kp LC(B)           &kp LCTRL &kp LALT &kp LGUI  &kp RCTRL           &kp LC(B) &kp H  &kp J      &kp K        &kp L    &kp SEMI &kp SQT
-        &kp LSHFT &kp Z     &kp X    &kp C    &kp V      &kp B                                &kp HOME &kp PG_UP                               &kp N  &kp M      &kp COMMA    &kp DOT  &kp FSLH &kp RSHFT
-        &mo 2     &kp GRAVE &kp CAPS &kp LEFT &kp RIGHT                    &kp BSPC &kp DEL   &kp END  &kp PG_DN &kp ENTER &kp SPACE                  &up_volume &down_volume &kp LBKT &kp RBKT &mo 2
+        &kp EQUAL &kp N1    &kp N2   &kp N3   &kp N4     &kp N5 &tog 1                                                              &mo 3     &kp N6 &kp N7 &kp N8    &kp N9   &kp N0   &kp MINUS
+        &kp TAB   &kp Q     &kp W    &kp E    &kp R      &kp T  &none                                                               &none     &kp Y  &kp U  &kp I     &kp O    &kp P    &kp BSLH
+        &kp ESC   &kp A     &kp S    &kp D    &kp F      &kp G  &kp LC(B)          &kp LCTRL &kp LALT &kp LGUI  &kp RCTRL           &kp LC(B) &kp H  &kp J  &kp K     &kp L    &kp SEMI &kp SQT
+        &kp LSHFT &kp Z     &kp X    &kp C    &kp V      &kp B                               &kp HOME &kp PG_UP                               &kp N  &kp M  &kp COMMA &kp DOT  &kp FSLH &kp RSHFT
+        &mo 2     &kp GRAVE &kp CAPS &kp LEFT &kp RIGHT                   &kp BSPC &kp DEL   &kp END  &kp PG_DN &kp ENTER &kp SPACE                  &kp UP &kp DOWN  &kp LBKT &kp RBKT &mo 2
       >;
     };
     keypad {
@@ -160,11 +102,11 @@
     fn {
       display-name = "Fn";
       bindings = <
-        &kp F1 &kp F2 &kp F3 &kp F4 &kp F5 &kp F6 &tog 1                                           &mo 3 &kp F7 &kp F8 &kp F9 &kp F10 &kp F11 &kp F12
-        &trans &trans &trans &trans &trans &trans  &none                                           &none &trans &trans &trans &trans  &trans  &trans
-        &trans &trans &trans &trans &trans &trans  &none        &trans &trans &trans &trans        &none &trans &trans &trans &trans  &trans  &trans
-        &trans &trans &trans &trans &trans &trans                      &trans &trans                     &trans &trans &trans &trans  &trans  &trans
-        &trans &trans &trans &trans &trans               &trans &trans &trans &trans &trans &trans              &trans &trans &trans  &trans  &trans
+        &kp F1 &kp F2 &kp F3 &kp F4         &kp F5     &kp F6  &tog 1                                                     &mo 3            &kp F7 &kp F8 &kp F9 &kp F10 &kp F11 &kp F12
+        &trans &trans &trans &trans         &trans     &trans  &none                                                      &none            &trans &trans &trans &trans  &trans  &trans
+        &trans &trans &trans &trans         &trans     &trans  &kp C_PLAY_PAUSE        &trans &trans &trans &trans        &kp C_PLAY_PAUSE &trans &trans &trans &trans  &trans  &trans
+        &trans &trans &trans &trans         &trans     &trans                                 &trans &trans                                &trans &trans &trans &trans  &trans  &trans
+        &trans &trans &trans &kp C_PREVIOUS &kp C_NEXT                          &trans &trans &trans &trans &trans &trans                          &trans &trans &trans  &trans  &trans
       >;
     };
     mod {

--- a/config/adv360_original.keymap
+++ b/config/adv360_original.keymap
@@ -6,6 +6,64 @@
 #include <dt-bindings/zmk/backlight.h>
 #include <dt-bindings/zmk/pointing.h>
 
+// #define KEYS_LEFT 0 1 2 3 4 5 6 \
+//                   14 15 16 17 18 19 20 \
+//                   28 29 30 31 32 33 34 \
+//                   46 47 48 49 50 51 \
+//                   60 61 62 63 64
+
+// #define KEYS_RIGHT 7 8 9 10 11 12 13 \
+//                    21 22 23 24 25 26 27 \
+//                    39 40 41 42 43 44 45 \
+//                    54 55 56 57 58 59 \
+//                    71 72 73 74 75
+
+// #define THUMBS_LEFT 35 36 52 65 66 67
+
+// #define THUMBS_RIGHT 37 38 53 68 69 70
+
+/ {
+    combos {
+      compatible = "zmk,combos";
+      combo_volume_up {
+        timeout-ms = <50>;
+        key-positions = <46 71>;
+        // Alternative: C_VOLUME_UP
+        binding = <&kp K_VOLUME_UP>;
+      };
+      combo_volume_down {
+        timeout-ms = <50>;
+        key-positions = <46 72>;
+        // Alternative: C_VOLUME_DOWN
+        binding = <&kp K_VOLUME_DOWN>;
+      };
+      combo_media_next {
+        timeout-ms = <50>;
+        key-positions = <59 64>;
+        // Alternative: C_NEXT
+        binding = <&kp K_NEXT>;
+      };
+      combo_media_prev {
+        timeout-ms = <50>;
+        key-positions = <59 63>;
+        // Alternative: C_PREVIOUS
+        binding = <&kp K_PREVIOUS>;
+      };
+      combo_media_play_pause_1 {
+        timeout-ms = <50>;
+        key-positions = <39 46>;
+        // Alternative: C_PLAY_PAUSE
+        binding = <&kp K_PLAY_PAUSE>;
+      };
+      combo_media_play_pause_2 {
+        timeout-ms = <50>;
+        key-positions = <34 59>;
+        // Alternative: C_PLAY_PAUSE
+        binding = <&kp K_PLAY_PAUSE>;
+      };
+    };
+};
+
 / {
     behaviors {
       #include "macros.dtsi"
@@ -28,11 +86,11 @@
     default_layer {
       display-name = "Base";
       bindings = <
-        &kp EQUAL &kp N1    &kp N2   &kp N3   &kp N4     &kp N5 &tog 1                                                           &mo 3 &kp N6 &kp N7 &kp N8    &kp N9   &kp N0   &kp MINUS
-        &kp TAB   &kp Q     &kp W    &kp E    &kp R      &kp T  &none                                                            &none &kp Y  &kp U  &kp I     &kp O    &kp P    &kp BSLH
-        &kp ESC   &kp A     &kp S    &kp D    &kp F      &kp G  &none           &kp LCTRL &kp LALT &kp LGUI  &kp RCTRL           &none &kp H  &kp J  &kp K     &kp L    &kp SEMI &kp SQT
-        &kp LSHFT &kp Z     &kp X    &kp C    &kp V      &kp B                            &kp HOME &kp PG_UP                           &kp N  &kp M  &kp COMMA &kp DOT  &kp FSLH &kp RSHFT
-        &mo 2     &kp GRAVE &kp CAPS &kp LEFT &kp RIGHT                &kp BSPC &kp DEL   &kp END  &kp PG_DN &kp ENTER &kp SPACE              &kp UP &kp DOWN  &kp LBKT &kp RBKT &mo 2
+        &kp EQUAL &kp N1    &kp N2   &kp N3   &kp N4     &kp N5 &tog 1                                                               &mo 3     &kp N6 &kp N7 &kp N8    &kp N9   &kp N0   &kp MINUS
+        &kp TAB   &kp Q     &kp W    &kp E    &kp R      &kp T  &none                                                                &none     &kp Y  &kp U  &kp I     &kp O    &kp P    &kp BSLH
+        &kp ESC   &kp A     &kp S    &kp D    &kp F      &kp G  &kp LC(B)           &kp LCTRL &kp LALT &kp LGUI  &kp RCTRL           &kp LC(B) &kp H  &kp J  &kp K     &kp L    &kp SEMI &kp SQT
+        &kp LSHFT &kp Z     &kp X    &kp C    &kp V      &kp B                                &kp HOME &kp PG_UP                               &kp N  &kp M  &kp COMMA &kp DOT  &kp FSLH &kp RSHFT
+        &mo 2     &kp GRAVE &kp CAPS &kp LEFT &kp RIGHT                    &kp BSPC &kp DEL   &kp END  &kp PG_DN &kp ENTER &kp SPACE                  &kp UP &kp DOWN  &kp LBKT &kp RBKT &mo 2
       >;
     };
     keypad {

--- a/config/adv360_original.keymap
+++ b/config/adv360_original.keymap
@@ -29,37 +29,37 @@
         timeout-ms = <50>;
         key-positions = <46 71>;
         // Alternative: C_VOLUME_UP
-        binding = <&kp K_VOLUME_UP>;
+        bindings = <&kp K_VOLUME_UP>;
       };
       combo_volume_down {
         timeout-ms = <50>;
         key-positions = <46 72>;
         // Alternative: C_VOLUME_DOWN
-        binding = <&kp K_VOLUME_DOWN>;
+        bindings = <&kp K_VOLUME_DOWN>;
       };
       combo_media_next {
         timeout-ms = <50>;
         key-positions = <59 64>;
         // Alternative: C_NEXT
-        binding = <&kp K_NEXT>;
+        bindings = <&kp K_NEXT>;
       };
       combo_media_prev {
         timeout-ms = <50>;
         key-positions = <59 63>;
         // Alternative: C_PREVIOUS
-        binding = <&kp K_PREVIOUS>;
+        bindings = <&kp K_PREVIOUS>;
       };
       combo_media_play_pause_1 {
         timeout-ms = <50>;
         key-positions = <39 46>;
         // Alternative: C_PLAY_PAUSE
-        binding = <&kp K_PLAY_PAUSE>;
+        bindings = <&kp K_PLAY_PAUSE>;
       };
       combo_media_play_pause_2 {
         timeout-ms = <50>;
         key-positions = <34 59>;
         // Alternative: C_PLAY_PAUSE
-        binding = <&kp K_PLAY_PAUSE>;
+        bindings = <&kp K_PLAY_PAUSE>;
       };
     };
 };


### PR DESCRIPTION
## Advantage 360 Pro PR template

### What's changed:
* Created 'tmux' hotkey assigned to Macro2 and Macro4 on base layer.
* Added C_VOLUME_UP/DOWN to UP/DOWN in Fn layer.
* Added C_PREVIOUS/NEXT to LEFT/RIGHT in Fn layer.
* Added C_PLAY_PAUSE to Macro2 and Macro4 in Fn layer.
* Disabled same side shift for B, Y, and ^ to enforce opposite shift functionality in MonkeyType.
* Swapped LSHFT+EQUAL and RSHFT+EQUAL to fix opposite shift functionality in MonkeyType.
* Copied config as backup of default.

### Why has this change been implemented:
Media controls are essential, as is the enforcement of opposite shift mode during touch typing training. Also tmux convenience.

### What (if any) actions must a user take after this change:
Touch typing training every day. Keep listening to music. Also get better at tmux.

